### PR TITLE
Color Loric characters green.

### DIFF
--- a/get_all_roles.py
+++ b/get_all_roles.py
@@ -11,6 +11,7 @@ def get_color_from_category(category):
       - "Minions" and "Demons" are red.
       - "Travellers" or "Travelers" are purple.
       - "Fabled" are yellow.
+      - "Loric" are green.
     If the category doesn't match any of these, return "unknown".
     """
     if category in ("Townsfolk", "Outsiders"):
@@ -21,6 +22,8 @@ def get_color_from_category(category):
         return "purple"
     elif category == "Fabled":
         return "yellow"
+    elif category == "Loric":
+        return "green"
     else:
         return "unknown"
 

--- a/tests/test_solid_maker.py
+++ b/tests/test_solid_maker.py
@@ -185,5 +185,8 @@ def test_get_color_from_category():
     # Test Fabled (yellow)
     assert get_color_from_category("Fabled") == "yellow"
 
+    # Test Loric (green)
+    assert get_color_from_category("Loric") == "green"
+
     # Test unknown category
     assert get_color_from_category("Unknown") == "unknown"


### PR DESCRIPTION
Add a simple mapping so Loric characters are colored green.

Note that get_all_roles is currently not finding all characters.  Many Fabled are no longer experimental so are not covered by urls_to_parse.  I'm happy to fix that, but not in my first PR to this project.
